### PR TITLE
Fix: Use correct artifact name in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: github-pages
+          name: artifact
           path: ./docs
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This PR fixes the deploy workflow by using the correct artifact name.\n\nFixes #33