### PR TITLE
fix(ci): reschedule daily post to 08:00 JST

### DIFF
--- a/.github/workflows/daily-post.yaml
+++ b/.github/workflows/daily-post.yaml
@@ -2,7 +2,7 @@ name: Daily Automated Post
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Daily at 00:00 UTC (09:00 JST)
+    - cron: '0 23 * * *' # Daily at 23:00 UTC (08:00 JST)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changed cron schedule from 09:00 JST (00:00 UTC) to 08:00 JST (23:00 UTC) to avoid GitHub Actions peak congestion.