### PR TITLE
fix(github-actions): re-enable workflow_dispatch for automerge

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -3,6 +3,7 @@ name: Auto-Merge AI Posts
 on:
   schedule:
     - cron: '0 * * * *' # Run every hour
+  workflow_dispatch: # Allow manual trigger
 
 permissions:
   contents: write


### PR DESCRIPTION
Enables manual trigger for the auto-merge workflow to allow debugging and ensure schedule registration.