### PR TITLE
``` chore: Adjust automerge workflow schedule frequency

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -2,7 +2,7 @@ name: Auto-Merge AI Posts
 
 on:
   schedule:
-    - cron: '45 * * * *' # Run every hour
+    - cron: '17 */3 * * *' # Run every hour
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
Updated the cron schedule for the 'Auto-Merge AI Posts' GitHub Actions workflow.
Previously, the workflow ran hourly at minute 45 (`45 * * * *`).
The new schedule sets it to run every three hours at minute 17 (`17 */3 * * *`).

This change reduces the overall execution frequency of the workflow.
```
