### PR TITLE
fix: masterへのpushでもdeployジョブが実行されるよう修正

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -75,7 +75,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     needs: build
-    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- `deploy` ジョブの `if` 条件に `push` イベントを追加
- 修正前は `schedule` と `workflow_dispatch` のみ対象で、masterへのpushマージ時にdeployがスキップされていた

## Test plan
- [ ] masterブランチへのマージ後、GitHub Actionsのdeployジョブが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)