### PR TITLE
docs: Claude Code と agy の協業プロトコルを導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,243 @@
+# CLAUDE.md — kuchida1981.github.io プロジェクト
+
+## プロジェクト概要
+
+Hugo で構築された個人ブログサイト（テーマ: PaperMod）。GitHub Pages でホスティング。
+
+- サイト: https://kuchida1981.github.io/
+- ビルド: `hugo` / `docker compose up`
+- コンテンツ: `content/` 以下に Markdown 記事
+- テーマ: `themes/papermod/`
+- 設定: `config.yml`
+
+## AI ツール役割分担
+
+このプロジェクトでは Claude Code と Antigravity CLI (agy) を役割に応じて使い分ける。
+
+| フェーズ | ツール | 理由 |
+|---------|--------|------|
+| 設計・調査・探索 | **Claude Code** | 設計能力・コードベース理解が高い |
+| 実装 | **Antigravity CLI** (`agy`) | Gemini クレジットを活用、Claude クレジットを節約 |
+| コードレビュー・PR作成 | **Claude Code** | `/code-review` スキルを使う |
+| レビュー指摘の修正 | **Antigravity CLI** (`agy`) | 実装担当が修正。Claude Code は修正内容を指示するのみ |
+
+### 難易度の目安
+
+- **低**: 記事の追加・修正、テンプレートの軽微な変更、2ファイル以内
+- **中**: 複数テンプレートにまたがる変更、新しいレイアウトの追加、config 変更を伴う
+- **高**: テーマのカスタマイズ、ワークフロー変更、スクリプトの大幅改修
+
+難易度が高い実装や、agy が行き詰まった場合は Claude Code に切り替える。
+
+### Claude Code から agy を呼び出す方法
+
+#### 方式の選択
+
+| 方式 | 条件 | 利点 |
+|------|------|------|
+| **MCP（推奨）** | `mcp__agy__antigravity_status` ツールが利用可能 | stdout バグ回避、会話継続が自然、タイムアウト問題が少ない |
+| **Bash（フォールバック）** | MCP未セットアップの環境 | セットアップ不要、どの環境でも動く |
+
+セッション開始時に `mcp__agy__antigravity_status` が呼べるか確認し、利用可能なら MCP 方式を使う。
+利用できなければ Bash 方式にフォールバックする。
+
+#### MCP 方式（推奨）
+
+MCPブリッジ経由でagyをサブエージェントとして呼び出す。
+
+```
+mcp__agy__antigravity_ask(prompt="<実装プロンプト>", workspace="<プロジェクトルート>")
+```
+
+- 新規タスク: `mcp__agy__antigravity_ask`
+- 追加指示・継続: `mcp__agy__antigravity_continue`
+- 診断（クォータ消費なし）: `mcp__agy__antigravity_status`
+
+#### Bash 方式（フォールバック）
+
+MCP が使えない環境では従来の Bash 経由で呼び出す:
+
+```bash
+GIT_TERMINAL_PROMPT=0 CI=true \
+  agy --dangerously-skip-permissions --print-timeout 3m --print "<実装プロンプト>" 2>&1
+```
+
+| タスク規模 | ファイル数 | タイムアウト |
+|-----------|-----------|------------|
+| 小 | 1-2 | `--print-timeout 3m` |
+| 中 | 3-5 | `--print-timeout 5m` |
+| 大 | 6+ | `--print-timeout 8m`（さらなる分割を検討） |
+
+`CI=true` の副作用でツールの動作が変わった場合は、当該環境変数を除外してプロンプト内ルールのみでハング予防する。
+
+#### 共通ルール（MCP・Bash 両方式共通）
+
+**タスク単位の分割呼び出し:**
+一括委譲ではなく、OpenSpec tasks.md の各タスクを個別の agy ワンショットで実行する。
+十分に小さいタスク（1ファイルの小変更）は Claude Code の判断でまとめてよい。
+各タスク完了後に `git status` / `git diff` で結果を確認してから次のタスクに進む。
+
+**プロンプトに含める内容:**
+- 実装対象ファイルと変更内容（具体的に）
+- 既存コードのパターン（コピーすべき書き方）
+- スコープ外の制約（「この2ファイルだけ触れ」など）
+- OpenSpec の change ディレクトリへの参照（`openspec/changes/<name>/` 以下）
+- **実装完了後に `git add <実装ファイル> && git commit -m "feat: <変更内容>"` でコミットすること**
+- **不明点・判断に迷う点がある場合は実装せず、`[QUESTION] ...` の形式で質問を出力すること**
+- **ハング予防ルール（以下の「agy プロンプトの必須ルール」セクション参照）**
+
+実装完了後は Claude Code で `git diff HEAD` または `git log` を確認してからレビューに進む。
+
+### agy プロンプトの必須ルール
+
+agy へのすべてのプロンプトに、以下のルールを必ず含める:
+
+```
+制約:
+- 対話的入力（y/n, パスワード等）を求めるコマンドは絶対に実行しないこと
+- 必ず非対話フラグ（--yes, -y, --no-input 等）を付けること
+- git push, npm publish など外部サービスへの送信は行わないこと
+- 対話的入力が必要な状況に遭遇したら、実行せず [QUESTION] で報告すること
+```
+
+### agy との対話ループ
+
+agy の出力に `[QUESTION]` が含まれる場合、以下のループで対応する:
+
+```
+agy 実行 (1回目)
+  ↓ 出力を解析
+  ├─ [QUESTION] なし → 実装完了、レビューへ
+  └─ [QUESTION] あり → 質問ごとに判定:
+       ├─ Claude Code が回答できる → 回答をまとめる
+       └─ 判断つかない / センシティブ → ユーザーに確認
+       ↓
+     agy 実行 (2回目: 回答を追加コンテキストとして渡す)
+       ↓ 再度出力を解析（同じループ）
+```
+
+- MCP 方式: `antigravity_continue` で追加コンテキストを渡す
+- Bash 方式: 新しい `agy --print` 呼び出しに回答を含める
+
+**ループの上限は 3 回**。3 回で解決しない場合は Claude Code が直接実装に切り替える。
+
+### agy 失敗時のリカバリ
+
+agy がタイムアウト・ハング・エラーで失敗した場合:
+
+```
+失敗発生
+  ↓
+git status / git diff で途中成果を確認
+  ├─ 成果あり → 継続指示を送る
+  │   MCP: antigravity_continue で残り作業を指示
+  │   Bash: --continue で再開
+  └─ 成果なし → 新規セッションで別アプローチを試行
+      ↓
+再試行も失敗（2回連続）
+  ↓
+Claude Code が直接実装に切り替える
+```
+
+Bash 方式の場合、`--print-timeout` が効かないケースがある。
+Bash ツールの `timeout` パラメータも併用し、agy プロセスが応答しない場合は `kill` して対処する。
+
+### agy 委譲時の判断基準
+
+**Claude Code がユーザーに確認すべきケース:**
+- ブログの方針・コンテンツに関する判断
+- 破壊的変更や後方互換性に関わる判断
+- ワークフロー（GitHub Actions）の変更
+- 複数の妥当な選択肢がありトレードオフが明確でない場合
+
+**Claude Code が自分で回答してよいケース:**
+- 既存コードのパターンやコンベンションに関する質問
+- Hugo テンプレートの書き方やファイル構成の確認
+- config.yml の設定値の確認
+- OpenSpec の design.md / specs から読み取れる仕様
+
+---
+
+## 開発ワークフロー
+
+### 機能追加・バグ修正の標準フロー
+
+```
+1. 設計 (Claude Code)
+   /opsx:explore  → 問題を探索し設計を固める
+   /opsx:propose  → change proposal を生成（proposal.md / design.md / specs / tasks.md）
+
+2. トピックブランチ作成 & proposal コミット (Claude Code)
+   git checkout -b feature/<change-name>
+   git add openspec/changes/<change-name>/
+   git commit -m "docs(openspec): propose <change-name>"
+
+3. 実装 (agy タスク単位 × N)
+   tasks.md の各タスクを個別の agy ワンショットで実行
+   MCP: mcp__agy__antigravity_ask(prompt="...", workspace="<プロジェクトルート>")
+   Bash: GIT_TERMINAL_PROMPT=0 CI=true agy --dangerously-skip-permissions --print-timeout 3m --print "..." 2>&1
+   → 各タスク完了後に git status / git diff で確認
+   → [QUESTION] があれば Claude Code が回答 or ユーザーに確認し再実行
+   → 失敗時は antigravity_continue / --continue で再開 or Claude Code が引き継ぐ
+   → agy が実装コードをコミットする（"feat: <変更内容>"）
+
+3.5. agy 別セッションレビュー (agy 新規セッション)
+   実装とは別の新規 agy セッションで diff をレビューさせる
+   → 変更要約（変更ファイル一覧、問題点、設計判断、テスト充足度）を出力させる
+   → Claude Code は要約をベースに最終レビューの判断材料にする
+   → 変更が 1 ファイル・20 行以下の場合はこのステップを省略してよい
+
+4. コードレビュー (Claude Code)
+   /code-review（agy レビュー結果も参考にしつつ最終判断）
+   → 指摘があれば、修正内容を具体的にまとめる
+
+5. レビュー指摘の修正 (agy)
+   Claude Code がレビュー結果から修正プロンプトを作成し agy に委譲する
+   → 修正対象ファイル・行・具体的な変更内容を指示する
+   → agy が修正コードをコミットする（"fix: <修正内容>"）
+   → 指摘がなければこのステップはスキップ
+
+6. PR 作成 & OpenSpec アーカイブ (Claude Code)
+   /opsx:archive  → change をアーカイブ（delta spec sync を含む）
+   gh pr create
+   → アーカイブと spec sync のコミットを PR に含める
+
+7. CI 確認 (Claude Code)
+   gh pr checks --watch
+   → 失敗したら是正してプッシュし、再度 watch する
+```
+
+### ドキュメント更新の原則
+
+**設計・実装・レビューのすべての場面で常に検討すること。**
+
+- 仕様変更・機能追加があれば `openspec/specs/` の対応する spec.md を更新する
+- CLAUDE.md 自体のワークフローや規約が変わったときは即座に更新する
+- agy への実装プロンプトにも「関連ドキュメントの更新が必要か検討すること」を明示する
+
+### CI / pre-commit ルール
+
+**pre-commit のスキップ禁止**
+`--no-verify` や `SKIP=...` による pre-commit フックのスキップは一切行わない。
+フックが失敗した場合は、スキップせず根本原因を修正してから再コミットする。
+
+**git force push の禁止**
+`git push` 時の `force` オプション（`-f`、`--force`、`--force-with-lease`）の使用は原則禁止。
+コミットの修正や追加の変更が発生した場合は、新しいコミットを追加して通常のプッシュを行う。
+
+### OpenSpec チートシート
+
+| スキル | 用途 |
+|--------|------|
+| `/opsx:explore` | アイデア・問題を探索する（実装しない） |
+| `/opsx:propose` | change proposal を一括生成 |
+| `/opsx:apply` | tasks.md のタスクを順に実装（Claude Code が担当する場合） |
+| `/opsx:sync` | delta spec を main spec にマージ |
+| `/opsx:archive` | 完了した change をアーカイブ（PR 作成前に実施） |
+
+### ブランチ命名規則
+
+```
+feature/<change-name>   # 機能追加（OpenSpec change 名と一致させる）
+fix/<change-name>       # バグ修正
+```

--- a/openspec/specs/agy-invocation-protocol/spec.md
+++ b/openspec/specs/agy-invocation-protocol/spec.md
@@ -1,0 +1,66 @@
+# Capability: agy-invocation-protocol
+
+## Purpose
+
+agy（Antigravity CLI）を Claude Code から呼び出す際のプロトコルを定義する。タイムアウト制御、ハング予防、タスク分割、リカバリの各ルールを規定し、安定した自動実装を実現する。
+
+## Requirements
+
+### Requirement: タイムアウト付き呼び出し
+Claude Code から agy を呼び出す際、`--print-timeout` を必ず指定しなければならない（MUST）。デフォルト値は `3m` とし、タスクの規模に応じて調整する。
+
+#### Scenario: 標準的なタスク実行
+- **WHEN** Claude Code がタスク単位で agy に実装を委譲する
+- **THEN** `agy --dangerously-skip-permissions --print-timeout 3m --print "<プロンプト>" 2>&1` の形式で呼び出す
+
+#### Scenario: 大きなタスクの実行
+- **WHEN** 対象タスクが 6 ファイル以上に及ぶ
+- **THEN** `--print-timeout` を最大 `8m` まで延長するか、タスクをさらに分割する
+
+### Requirement: ハング予防の環境変数
+agy 呼び出し時に、対話的プロンプトを抑制する環境変数を設定しなければならない（MUST）。
+
+#### Scenario: 環境変数付き呼び出し
+- **WHEN** Claude Code が agy を呼び出す
+- **THEN** `GIT_TERMINAL_PROMPT=0` と `CI=true` を環境変数として付与する
+
+#### Scenario: 環境変数の副作用発生
+- **WHEN** `CI=true` によりツールの動作が意図せず変わった場合
+- **THEN** 当該環境変数を除外し、プロンプト内のルールのみでハング予防する
+
+### Requirement: プロンプト内のハング予防ルール
+agy へのすべてのプロンプトに、対話的入力を禁止するルールを含めなければならない（MUST）。
+
+#### Scenario: ハング予防ルールの適用
+- **WHEN** Claude Code が agy へのプロンプトを構成する
+- **THEN** 以下のルールをプロンプトに含める:
+  - 対話的入力（y/n、パスワード等）を求めるコマンドは実行しない
+  - 非対話フラグ（--yes, -y, --no-input 等）を必ず付ける
+  - git push, npm publish など外部サービスへの送信は行わない
+  - 対話的入力が必要な場合は [QUESTION] で報告する
+
+### Requirement: タスク単位の分割呼び出し
+OpenSpec tasks.md の各タスクを個別の agy ワンショットで実行しなければならない（MUST）。ただし、十分に小さいタスクは結合してよい（MAY）。
+
+#### Scenario: 複数タスクの順次実行
+- **WHEN** tasks.md に Task-1, Task-2, Task-3 がある
+- **THEN** Claude Code は各タスクを個別の agy 呼び出しで実行し、各完了後に `git status` / `git diff` で結果を確認する
+
+#### Scenario: 小タスクの結合
+- **WHEN** 連続するタスクがいずれも 1 ファイルの小変更である
+- **THEN** Claude Code の判断でこれらを 1 回の agy 呼び出しにまとめてよい
+
+### Requirement: タイムアウト時のリカバリ
+agy がタイムアウトした場合、`--continue` による再開を試みなければならない（MUST）。再開が 2 回失敗したら Claude Code が直接実装に切り替える。
+
+#### Scenario: タイムアウト後の再開
+- **WHEN** agy の実行が `--print-timeout` で中断された
+- **THEN** Claude Code は `git status` で途中成果を確認し、`agy --continue --print "<再開指示>"` で同じ会話を再開する
+
+#### Scenario: 再開の連続失敗
+- **WHEN** `--continue` による再開が 2 回連続で失敗（タイムアウトまたはエラー）した
+- **THEN** Claude Code が直接実装に切り替える
+
+#### Scenario: 途中成果がない場合
+- **WHEN** タイムアウト後に `git status` で変更が確認できない
+- **THEN** 新規セッション（`--continue` なし）で別アプローチを試みる


### PR DESCRIPTION
## Summary
- video-ratings プロジェクトの agy 協業の仕組みをベースに、本プロジェクトにも同様の仕組みを導入
- `CLAUDE.md` に AI ツール役割分担・agy 呼び出し方法（MCP推奨/Bashフォールバック）・開発ワークフローを記述
- `openspec/specs/agy-invocation-protocol/spec.md` にタイムアウト制御・ハング予防・タスク分割・リカバリの正式プロトコルを追加

## Test plan
- [ ] CLAUDE.md の内容が Hugo ブログプロジェクトに適した記述になっていることを確認
- [ ] agy-invocation-protocol spec が video-ratings 版と整合していることを確認
- [ ] 次回セッションで agy MCP 呼び出しが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)